### PR TITLE
Add belongs_to, and some cleanup

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,78 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features)
+
+## Uncomment to clear the screen before every task
+# clearing :on
+
+## Guard internally checks for changes in the Guardfile and exits.
+## If you want Guard to automatically start up again, run guard in a
+## shell loop, e.g.:
+##
+##  $ while bundle exec guard; do echo "Restarting Guard..."; done
+##
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+  watch(ruby.lib_files){|m| rspec.spec.(m[1].gsub('lib/', '')) }
+
+  # # Rails files
+  # rails = dsl.rails(view_extensions: %w(erb haml slim))
+  # dsl.watch_spec_files_for(rails.app_files)
+  # dsl.watch_spec_files_for(rails.views)
+
+  # watch(rails.controllers) do |m|
+  #   [
+  #     rspec.spec.("routing/#{m[1]}_routing"),
+  #     rspec.spec.("controllers/#{m[1]}_controller"),
+  #     rspec.spec.("acceptance/#{m[1]}")
+  #   ]
+  # end
+
+  # # Rails config changes
+  # watch(rails.spec_helper)     { rspec.spec_dir }
+  # watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  # watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # # Capybara features specs
+  # watch(rails.view_dirs)     { |m| rspec.spec.("features/#{m[1]}") }
+
+  # # Turnip features and steps
+  # watch(%r{^spec/acceptance/(.+)\.feature$})
+  # watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+  #   Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  # end
+end

--- a/lib/plaza/adapters/base_adapter.rb
+++ b/lib/plaza/adapters/base_adapter.rb
@@ -32,7 +32,7 @@ module Plaza
         if response.body.kind_of? Hash
           response.body
         else
-          JSON.parse(response)
+          JSON.parse(response.body)
         end
       rescue JSON::ParserError=> jsonError
         error = Plaza::Error.new(jsonError, jsonError.message)

--- a/lib/plaza/connection.rb
+++ b/lib/plaza/connection.rb
@@ -11,14 +11,14 @@ module Plaza
         config.middleware.each do |middleware|
           conn.use middleware
         end
-        
-        conn.use :http_cache, store: config.cache_store, logger: config.logger if config.cache_store
+
+        conn.use :http_cache, store: config.cache_store, logger: config.logger
 
         conn.headers[:accept] = 'application/json'
 
         conn.adapter Faraday.default_adapter
         conn.response :selective_errors, except: [422]
-        conn.use :extended_logging, logger: config.logger 
+        conn.use :extended_logging, logger: config.logger
       end
     end
 

--- a/lib/plaza/models/associations.rb
+++ b/lib/plaza/models/associations.rb
@@ -1,0 +1,66 @@
+module Plaza
+  module Associations
+
+    def self.included(base)
+      # base.class_eval do
+      # end
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      # Class Configuration
+      #
+      def has_many(*relations)
+        relations.each do |r|
+          define_method(sym = association_symbol_for(r)) do
+            class_for(r).collection(adapter.has_many(self.id,sym))
+          end
+        end
+      end
+
+      def belongs_to(*relations)
+        relations.each do |r|
+          define_method(sym = association_symbol_for(r)) do
+            class_for(r).find(self.send("#{sym}_id"))
+          end
+        end
+      end
+
+      private
+
+      def association_symbol_for(identifier)
+        if identifier.kind_of?(Class) && identifier.respond_to?(:plural_name)
+          identifier.plural_name
+        elsif identifier.kind_of? String
+          Inflector.tableize(identifier.split('::').last)
+        elsif identifier.kind_of? Symbol
+          identifier
+        else
+          raise TypeError.new("Can't convert to association symbol")
+        end
+      end
+    end
+
+    protected
+    def namespace
+      namespace = self.class.to_s.split("::")[0...-1].join("::")
+      Kernel.const_get(namespace) unless namespace.empty?
+    end
+    def class_for(identifier)
+      if identifier.kind_of?(Symbol)
+        _name = Plaza::Inflector.classify(identifier.to_s)
+        if namespace && namespace.const_defined?(_name)
+          klass = namespace.const_get(_name)
+        else
+          klass = Kernel.const_get(_name)
+        end
+      elsif identifier.kind_of?(String)
+        klass = Object.const_get(identifier)
+      elsif identifier.kind_of?(Class)
+        klass = identifier
+      else
+        raise TypeError.new("Can't convert to has_many relation")
+      end
+    end
+  end
+end

--- a/lib/plaza/models/error.rb
+++ b/lib/plaza/models/error.rb
@@ -9,7 +9,11 @@ module Plaza
     end
 
     def status
-      response.respond_to?(:code) ? response.code : nil
+      if response.kind_of?(Hash)
+       response[:status]
+      else
+        response.respond_to?(:code) ? response.code : nil
+      end
     end
 
     def to_s

--- a/lib/plaza/models/restful_model.rb
+++ b/lib/plaza/models/restful_model.rb
@@ -95,6 +95,7 @@ module Plaza
     end
 
     def save
+      self.errors = {}
       begin
         if persisted?
           self.attributes = self.class.adapter.update(self.id, self.serialize)

--- a/lib/plaza/models/restful_model.rb
+++ b/lib/plaza/models/restful_model.rb
@@ -10,6 +10,7 @@ module Plaza
       base.class_eval do
         include Virtus.model
         include Plaza::BaseModel
+        include Plaza::Associations
         attribute :id,     Integer
         attribute :errors, Hash
 
@@ -26,8 +27,8 @@ module Plaza
 
     module ClassMethods
 
-      def all
-        collection(adapter.index)
+      def all(attributes=nil)
+        collection(adapter.index(attributes))
       end
 
       def find(id)
@@ -44,7 +45,7 @@ module Plaza
       end
 
       def where(attributes)
-        collection( adapter.index(attributes) )
+        all(attributes)
       end
 
       def plural_name
@@ -53,16 +54,6 @@ module Plaza
 
       def singular_name
         self.to_s.split('::').last.scan(/[A-Z][a-z]+/).join('_').downcase
-      end
-
-      # Class Configuration
-      #
-      def has_many(*relations)
-        relations.each do |r|
-          define_method(sym = has_many_symbol_for(r)) do
-            class_for(r).collection(adapter.has_many(self.id,sym))
-          end
-        end
       end
 
       def restricted_attributes(*args)
@@ -76,21 +67,6 @@ module Plaza
       end
 
       alias_method :plaza_config=, :plaza_config
-
-      private
-
-      def has_many_symbol_for(identifier)
-        if identifier.kind_of? Class
-          identifier.plural_name
-        elsif identifier.kind_of? String
-          Inflector.tableize(identifier.split('::').last)
-        elsif identifier.kind_of? Symbol
-          identifier
-        else
-          raise TypeError.new("Can't convert to has_many symbol")
-        end
-      end
-
 
     end
 
@@ -111,16 +87,16 @@ module Plaza
     end
 
     def new_record?
-      !persisted?
+      self.id.nil?
     end
 
     def persisted?
-      self.id.present?
+      !new_record?
     end
 
     def save
       begin
-        if self.id
+        if persisted?
           self.attributes = self.class.adapter.update(self.id, self.serialize)
         else
           self.attributes = self.class.adapter.create(self.serialize)
@@ -155,32 +131,11 @@ module Plaza
         raise NoMethodError.new "undefined method '#{method_name}' for #{self.class}"
       end
     end
-    
+
     def plural_name
       self.class.plural_name
     end
 
-    protected
-    def namespace
-      Kernel.const_get(self.class.to_s.split("::")[0...-1].join("::"))
-    end
-
-    def class_for(identifier)
-      if identifier.kind_of?(Symbol)
-        _name = Plaza::Inflector.classify(identifier.to_s)
-        if namespace.const_defined?(_name)
-          klass = namespace.const_get(_name)
-        else
-          klass = Kernel.const_get(_name)
-        end
-      elsif identifier.kind_of?(String)
-        klass = Object.const_get(identifier)
-      elsif identifier.kind_of?(Class)
-        klass = identifier
-      else
-        raise TypeError.new("Can't convert to has_many relation")
-      end
-    end
 
   end
 end

--- a/spec/plaza/adapters/restful_adapter_spec.rb
+++ b/spec/plaza/adapters/restful_adapter_spec.rb
@@ -22,7 +22,7 @@ describe RestfulAdapter do
       expect{adapter.show(1000)}.to raise_error{ |error|
         error.should be_a(Plaza::Error)
         error.status.should == 404
-        error.message.should =~ /Couldn't find/
+        error.message.should =~ /Resource Not Found/
       }
     end
 

--- a/spec/plaza/models/restful_model_spec.rb
+++ b/spec/plaza/models/restful_model_spec.rb
@@ -222,6 +222,21 @@ describe Thing do
         expect(thing.id).to eq 42
       end
 
+      it 'should clear errors on subsequent saves' do
+        valid_name = 'New Thing'
+        error_hash = {body: {'errors'=>{name: 'must be more than 5 characters'}}.to_json, status: 422}
+        valid_hash = {body: {name: valid_name}.to_json, status: 200}
+        stub_request(:post, 'http://example.com/rest/things.json').to_return(error_hash, valid_hash ) #multiple response for same call, happens in order
+        thing = Thing.new(name:valid_name[0..3])
+        expect(thing.save).to be_falsey
+        expect(thing.errors).not_to be_empty
+        thing.name=valid_name
+        thing.save
+        expect(thing.save).to be_truthy
+        expect(thing.errors).to be_empty
+      end
+
+
     end
 
     context 'when thing has an id' do


### PR DESCRIPTION
Add an explicit belongs_to association that will always return an object gotten over rest vs the implicit one used today

make it so that '#all' can accept attributes, and make it so that '#where' calls '#all'
remove unsupported 'present?' call and change to logic that should work